### PR TITLE
Fix datapusher dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ repoze.who==2.0
 repoze.who-friendlyform==1.0.8
 requests==2.3.0
 simplejson==3.3.1
-six==1.7.3
+six==1.10.0
 solrpy==0.9.5
 sqlalchemy-migrate==0.9.1
 sqlparse==0.1.11


### PR DESCRIPTION
Fix "six" requirement to be compatible with html5lib==0.999999999 (1.0b10), which is imported by messytables.